### PR TITLE
Don't call `string.format` on data to copy via OSC52

### DIFF
--- a/lua/smartyank/init.lua
+++ b/lua/smartyank/init.lua
@@ -32,9 +32,9 @@ M.setup = function(opts)
 end
 
 M.osc52printf = function(...)
-  local str = string.format(...)
+  local str = ...
   local base64 = require('smartyank.base64').encode(str)
-  local osc52str = string.format("\x1b]52;c;%s\x07", base64)
+  local osc52str = "\x1b]52;c;" .. base64 .. "\x07"
   local bytes = vim.fn.chansend(vim.v.stderr, osc52str)
   assert(bytes > 0)
   if not __config.osc52.silent then


### PR DESCRIPTION
Copying any special characters interpreted by `string.format` over SSH doesn't currently work. This change allows copying of characters that `string.format` would otherwise try to replace, such as "%".