### PR TITLE
Fix OSC52 escape sequence formatting issue

### DIFF
--- a/lua/smartyank/init.lua
+++ b/lua/smartyank/init.lua
@@ -45,7 +45,7 @@ end
 M.osc52printf = function(str, type)
   local base64 = require("smartyank.base64").encode(str)
   local osc52str = type == "tmux"
-      and string.format("\x1bPtmux;\x1b\x1b]52;c;%s\x07\x1b\\\\", base64)
+      and string.format("\x1bPtmux;\x1b\x1b]52;c;%s\x07\x1b\\", base64)
       or string.format("\x1b]52;c;%s\x07", base64)
   local bytes = vim.fn.chansend(vim.v.stderr, osc52str)
   -- TODO: why does this return 0 on very large yanks? (#5)


### PR DESCRIPTION
before
![error](https://github.com/user-attachments/assets/9ef7b78e-0f87-4b29-b278-e88ba6bdd0d3)

after
![ok](https://github.com/user-attachments/assets/efa4f858-52e3-4d67-8027-666448e32866)
